### PR TITLE
update names in parameter update process

### DIFF
--- a/.github/workflows/updateParameters.yml
+++ b/.github/workflows/updateParameters.yml
@@ -38,8 +38,8 @@ jobs:
           echo "Updating Parameters"
           pwsh $GITHUB_WORKSPACE/configs/UpdateParameters.ps1 \
             -ConfigurationFilePath 'configs/config.json' \
-            -DataLandingZoneSubscriptionId '${{ env.DATA_HUB_SUBSCRIPTION_ID }}' \
-            -DataLandingZoneName '${{ env.DATA_HUB_NAME }}' \
+            -DataManagementZoneSubscriptionId '${{ env.DATA_HUB_SUBSCRIPTION_ID }}' \
+            -DataManagementZoneName '${{ env.DATA_HUB_NAME }}' \
             -Location '${{ env.LOCATION }}' \
             -AzureResourceManagerConnectionName '${{ env.AZURE_RESOURCE_MANAGER_CONNECTION_NAME }}'
       
@@ -56,13 +56,13 @@ jobs:
           \`\`\`YAML
           env:
             AZURE_SUBSCRIPTION_ID: '${{ env.DATA_HUB_SUBSCRIPTION_ID }}'
-            AZURE_RESOURCE_GROUP_NAME_NETWORK: '${{ steps.update_parameters.outputs.landingZoneName }}-network'
-            AZURE_RESOURCE_GROUP_NAME_GLOBAL_DNS: '${{ steps.update_parameters.outputs.landingZoneName }}-global-dns'
-            AZURE_RESOURCE_GROUP_NAME_AUTOMATION: '${{ steps.update_parameters.outputs.landingZoneName }}-automation'
-            AZURE_RESOURCE_GROUP_NAME_MANAGEMENT: '${{ steps.update_parameters.outputs.landingZoneName }}-mgmt'
-            AZURE_RESOURCE_GROUP_NAME_CONSUMPTION: '${{ steps.update_parameters.outputs.landingZoneName }}-consumption'
-            AZURE_RESOURCE_GROUP_NAME_CONTAINER: '${{ steps.update_parameters.outputs.landingZoneName }}-container'
-            AZURE_RESOURCE_GROUP_NAME_GOVERNANCE: '${{ steps.update_parameters.outputs.landingZoneName }}-governance'
+            AZURE_RESOURCE_GROUP_NAME_NETWORK: '${{ steps.update_parameters.outputs.managementZoneName }}-network'
+            AZURE_RESOURCE_GROUP_NAME_GLOBAL_DNS: '${{ steps.update_parameters.outputs.managementZoneName }}-global-dns'
+            AZURE_RESOURCE_GROUP_NAME_AUTOMATION: '${{ steps.update_parameters.outputs.managementZoneName }}-automation'
+            AZURE_RESOURCE_GROUP_NAME_MANAGEMENT: '${{ steps.update_parameters.outputs.managementZoneName }}-mgmt'
+            AZURE_RESOURCE_GROUP_NAME_CONSUMPTION: '${{ steps.update_parameters.outputs.managementZoneName }}-consumption'
+            AZURE_RESOURCE_GROUP_NAME_CONTAINER: '${{ steps.update_parameters.outputs.managementZoneName }}-container'
+            AZURE_RESOURCE_GROUP_NAME_GOVERNANCE: '${{ steps.update_parameters.outputs.managementZoneName }}-governance'
             AZURE_LOCATION: '${{ env.LOCATION }}'
           \`\`\`
           
@@ -74,13 +74,13 @@ jobs:
           variables:
             AZURE_RESOURCE_MANAGER_CONNECTION_NAME: '${{ env.AZURE_RESOURCE_MANAGER_CONNECTION_NAME }}'
             AZURE_SUBSCRIPTION_ID: '${{ env.DATA_HUB_SUBSCRIPTION_ID }}'
-            AZURE_RESOURCE_GROUP_NAME_NETWORK: '${{ steps.update_parameters.outputs.landingZoneName }}-network'
-            AZURE_RESOURCE_GROUP_NAME_GLOBAL_DNS: '${{ steps.update_parameters.outputs.landingZoneName }}-global-dns'
-            AZURE_RESOURCE_GROUP_NAME_AUTOMATION: '${{ steps.update_parameters.outputs.landingZoneName }}-automation'
-            AZURE_RESOURCE_GROUP_NAME_MANAGEMENT: '${{ steps.update_parameters.outputs.landingZoneName }}-mgmt'
-            AZURE_RESOURCE_GROUP_NAME_CONSUMPTION: '${{ steps.update_parameters.outputs.landingZoneName }}-consumption'
-            AZURE_RESOURCE_GROUP_NAME_CONTAINER: '${{ steps.update_parameters.outputs.landingZoneName }}-container'
-            AZURE_RESOURCE_GROUP_NAME_GOVERNANCE: '${{ steps.update_parameters.outputs.landingZoneName }}-governance'
+            AZURE_RESOURCE_GROUP_NAME_NETWORK: '${{ steps.update_parameters.outputs.managementZoneName }}-network'
+            AZURE_RESOURCE_GROUP_NAME_GLOBAL_DNS: '${{ steps.update_parameters.outputs.managementZoneName }}-global-dns'
+            AZURE_RESOURCE_GROUP_NAME_AUTOMATION: '${{ steps.update_parameters.outputs.managementZoneName }}-automation'
+            AZURE_RESOURCE_GROUP_NAME_MANAGEMENT: '${{ steps.update_parameters.outputs.managementZoneName }}-mgmt'
+            AZURE_RESOURCE_GROUP_NAME_CONSUMPTION: '${{ steps.update_parameters.outputs.managementZoneName }}-consumption'
+            AZURE_RESOURCE_GROUP_NAME_CONTAINER: '${{ steps.update_parameters.outputs.managementZoneName }}-container'
+            AZURE_RESOURCE_GROUP_NAME_GOVERNANCE: '${{ steps.update_parameters.outputs.managementZoneName }}-governance'
             AZURE_LOCATION: '${{ env.LOCATION }}'
           \`\`\`"
           body="${body//'%'/'%25'}"

--- a/configs/UpdateParameters.ps1
+++ b/configs/UpdateParameters.ps1
@@ -8,12 +8,12 @@ Param(
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [string]
-    $DataLandingZoneSubscriptionId,
+    $DataManagementZoneSubscriptionId,
 
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [string]
-    $DataLandingZoneName,
+    $DataManagementZoneName,
 
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
@@ -45,11 +45,11 @@ function Remove-SpecialCharsAndWhitespaces($InputString) {
 
 # Replace Special Characters
 Write-Host "Replacing Special Characters"
-$DataLandingZoneName = Remove-SpecialCharsAndWhitespaces -InputString $DataLandingZoneName
+$DataManagementZoneName = Remove-SpecialCharsAndWhitespaces -InputString $DataManagementZoneName
 
-# Reduce Length of DataLandingZoneName
-Write-Host "Reduce Length of DataLandingZoneName to Max 11 Characters"
-$DataLandingZoneName = -join $DataLandingZoneName[0..11]
+# Reduce Length of DataManagementZoneName
+Write-Host "Reduce Length of DataManagementZoneName to Max 11 Characters"
+$DataManagementZoneName = -join $DataManagementZoneName[0..11]
 
 # Loading Configuration File for Parameter Updates
 Write-Host "Loading Configuration File for Parameter Updates"
@@ -111,4 +111,4 @@ foreach ($config in $configs) {
 
 # Set output
 Write-Output "Setting output"
-Write-Output "::set-output name=landingZoneName::${DataLandingZoneName}"
+Write-Output "::set-output name=managementZoneName::${DataManagementZoneName}"

--- a/configs/config.json
+++ b/configs/config.json
@@ -4,7 +4,7 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.storageAccountName.value": "${DataLandingZoneName}artifactsa001"
+            "parameters.storageAccountName.value": "${DataManagementZoneName}artifactsa001"
         }
     },
     {
@@ -12,9 +12,9 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.containerRegistryName.value": "${DataLandingZoneName}containerregistry001",
-            "parameters.subnetId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataLandingZoneName}-vnet/subnets/${DataLandingZoneName}-privatelink-subnet",
-            "parameters.privateDnsZoneId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.azurecr.io"
+            "parameters.containerRegistryName.value": "${DataManagementZoneName}containerregistry001",
+            "parameters.subnetId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataManagementZoneName}-vnet/subnets/${DataManagementZoneName}-privatelink-subnet",
+            "parameters.privateDnsZoneId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.azurecr.io"
         }
     },
     {
@@ -22,9 +22,9 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.vmssName.value": "${DataLandingZoneName}dnsproxy001",
-            "parameters.storageAccountId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Storage/storageAccounts/${DataLandingZoneName}artifactsa001",
-            "parameters.subnetId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataLandingZoneName}-vnet/subnets/${DataLandingZoneName}-subnet"
+            "parameters.vmssName.value": "${DataManagementZoneName}dnsproxy001",
+            "parameters.storageAccountId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Storage/storageAccounts/${DataManagementZoneName}artifactsa001",
+            "parameters.subnetId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataManagementZoneName}-vnet/subnets/${DataManagementZoneName}-subnet"
         }
     },
     {
@@ -32,9 +32,9 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.firewallName.value": "${DataLandingZoneName}-firewall",
-            "parameters.firewallPolicyId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/firewallPolicies/${DataLandingZoneName}-firewallpolicy",
-            "parameters.subnetId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataLandingZoneName}-vnet/subnets/AzureFirewallSubnet"
+            "parameters.firewallName.value": "${DataManagementZoneName}-firewall",
+            "parameters.firewallPolicyId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/firewallPolicies/${DataManagementZoneName}-firewallpolicy",
+            "parameters.subnetId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataManagementZoneName}-vnet/subnets/AzureFirewallSubnet"
         }
     },
     {
@@ -42,7 +42,7 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.firewallPolicyName.value": "${DataLandingZoneName}-firewallpolicy"
+            "parameters.firewallPolicyName.value": "${DataManagementZoneName}-firewallpolicy"
         }
     },
     {
@@ -50,24 +50,24 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.keyVaultName.value": "${DataLandingZoneName}-keyvault001",
-            "parameters.subnetId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataLandingZoneName}-vnet/subnets/${DataLandingZoneName}-privatelink-subnet",
-            "parameters.privateDnsZoneId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
+            "parameters.keyVaultName.value": "${DataManagementZoneName}-keyvault001",
+            "parameters.subnetId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataManagementZoneName}-vnet/subnets/${DataManagementZoneName}-privatelink-subnet",
+            "parameters.privateDnsZoneId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
         }
     },
     {
         "filePath": "infra/PrivateDns/params.privateDns001.json",
         "fileType": "json",
         "parameters": {
-            "parameters.virtualNetworkId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataLandingZoneName}-vnet"
+            "parameters.virtualNetworkId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataManagementZoneName}-vnet"
         }
     },
     {
         "filePath": "infra/Purview/params.purview001.json",
         "fileType": "json",
         "parameters": {
-            "parameters.purviewName.value": "${DataLandingZoneName}-purview001",
-            "parameters.keyVaultId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-governance/providers/Microsoft.KeyVault/vaults/${DataLandingZoneName}-keyvault001"
+            "parameters.purviewName.value": "${DataManagementZoneName}-purview001",
+            "parameters.keyVaultId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-governance/providers/Microsoft.KeyVault/vaults/${DataManagementZoneName}-keyvault001"
         }
     },
     {
@@ -75,9 +75,9 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.synapsePrivateLinkHubName.value": "${DataLandingZoneName}synapseprivatelinkhub001",
-            "parameters.subnetId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataLandingZoneName}-vnet/subnets/${DataLandingZoneName}-privatelink-subnet",
-            "parameters.privateDnsZoneId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.azuresynapse.net"
+            "parameters.synapsePrivateLinkHubName.value": "${DataManagementZoneName}synapseprivatelinkhub001",
+            "parameters.subnetId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataManagementZoneName}-vnet/subnets/${DataManagementZoneName}-privatelink-subnet",
+            "parameters.privateDnsZoneId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.azuresynapse.net"
         }
     },
     {
@@ -85,8 +85,8 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.vnetName.value": "${DataLandingZoneName}-vnet",
-            "parameters.dataHubName.value": "${DataLandingZoneName}"
+            "parameters.vnetName.value": "${DataManagementZoneName}-vnet",
+            "parameters.dataHubName.value": "${DataManagementZoneName}"
         }
     },
     {
@@ -94,7 +94,7 @@
         "fileType": "json",
         "parameters": {
             "parameters.location.value": "${Location}",
-            "parameters.sourceVnetId.value": "/subscriptions/${DataLandingZoneSubscriptionId}/resourceGroups/${DataLandingZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataLandingZoneName}-vnet",
+            "parameters.sourceVnetId.value": "/subscriptions/${DataManagementZoneSubscriptionId}/resourceGroups/${DataManagementZoneName}-network/providers/Microsoft.Network/virtualNetworks/${DataManagementZoneName}-vnet",
             "parameters.destinationVnetId.value": "NodeVnetId"
         }
     }


### PR DESCRIPTION
**This PR fixes #39 **

Renamed variables like `DataLandingZoneName` to `DataManagementZoneName` so that users will understand the purpose of the variables and not be confused about what we're creating with this process.