### PR TITLE
Improve Firewall Rule Definitions and DNS Setup

### DIFF
--- a/.github/linters/.arm-ttk.psd1
+++ b/.github/linters/.arm-ttk.psd1
@@ -9,5 +9,6 @@
         'DependsOn Best Practices'
         'IDs Should Be Derived From ResourceIDs'
         'Parameters Must Be Referenced'
+        'Variables Must Be Referenced'
     )
 }

--- a/.github/linters/.arm-ttk.psd1
+++ b/.github/linters/.arm-ttk.psd1
@@ -8,5 +8,6 @@
         'DeploymentTemplate Must Not Contain Hardcoded Uri'
         'DependsOn Best Practices'
         'IDs Should Be Derived From ResourceIDs'
+        'Parameters Must Be Referenced'
     )
 }

--- a/docs/reference/portal.dataManagementZone.json
+++ b/docs/reference/portal.dataManagementZone.json
@@ -367,7 +367,7 @@
                         },
                         {
                             "name": "firewallConfiguration",
-                            "label": "Firewall Configuration",
+                            "label": "Firewall & DNS Configuration",
                             "type": "Microsoft.Common.Section",
                             "visible": true,
                             "elements": [
@@ -430,6 +430,42 @@
                                     }
                                 },
                                 {
+                                    "name": "infoBoxFirewallRulesCustomDeployment",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'custom')]",
+                                    "options": {
+                                        "text": "Please follow the link and make sure you apply the network and application rules to your Firewall. Otherwise, functionality of some services inside your data platform will be limited or may not function. This includes but is not limited to DataFactory, Databricks, Azure Machine Learning and HDInsight.",
+                                        "style": "Warning",
+                                        "uri": "https://github.com/Azure/data-management-zone/blob/main/infra/modules/services/firewallPolicyRules.bicep"
+                                    }
+                                },
+                                {
+                                    "name": "existingDnsForwarderType",
+                                    "label": "Existing DNS Forwarder",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[equals(steps('connectivitySettings').firewallConfiguration.disableDnsAndFirewallDeployment, 'yes')]",
+                                    "defaultValue": "Azure Firewall",
+                                    "toolTip": "Select the DNS Forwarder that is used inside your environment.",
+                                    "multiselect": false,
+                                    "selectAll": false,
+                                    "filter": false,
+                                    "filterPlaceholder": "Filter items ...",
+                                    "multiLine": true,
+                                    "constraints": {
+                                        "allowedValues": [
+                                            {
+                                                "label": "Azure Firewall",
+                                                "value": "azureFirewall"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "custom"
+                                            }
+                                        ],
+                                        "required": true
+                                    }
+                                },
+                                {
                                     "name": "subscriptionFirewallApi",
                                     "type": "Microsoft.Solutions.ArmApiControl",
                                     "request": {
@@ -441,7 +477,7 @@
                                     "name": "azureFirewallSub",
                                     "label": "Azure Firewall Subscription",
                                     "type": "Microsoft.Common.DropDown",
-                                    "visible": "[equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'azureFirewall')]",
+                                    "visible": "[or(equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'azureFirewall'), equals(steps('connectivitySettings').firewallConfiguration.existingDnsForwarderType, 'azureFirewall'))]",
                                     "defaultValue": "",
                                     "toolTip": "Select the Subscription of your Azure Firewall.",
                                     "multiselect": false,
@@ -466,7 +502,7 @@
                                     "name": "azureFirewallId",
                                     "label": "Azure Firewall",
                                     "type": "Microsoft.Common.DropDown",
-                                    "visible": "[equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'azureFirewall')]",
+                                    "visible": "[or(equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'azureFirewall'), equals(steps('connectivitySettings').firewallConfiguration.existingDnsForwarderType, 'azureFirewall'))]",
                                     "defaultValue": "",
                                     "toolTip": "Select the central Azure Firewall that should be used.",
                                     "multiselect": false,
@@ -543,16 +579,6 @@
                                     }
                                 },
                                 {
-                                    "name": "infoBoxFirewallRulesCustomDeployment",
-                                    "type": "Microsoft.Common.InfoBox",
-                                    "visible": "[equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'custom')]",
-                                    "options": {
-                                        "text": "Please follow the link and make sure you apply the network and application rules to your Firewall. Otherwise, functionality of some services inside your data platform will be limited or may not function. This includes but is not limited to DataFactory, Databricks, Azure Machine Learning and HDInsight.",
-                                        "style": "Warning",
-                                        "uri": "https://github.com/Azure/data-management-zone/blob/main/infra/modules/services/firewallPolicyRules.bicep"
-                                    }
-                                },
-                                {
                                     "name": "firewallPrivateIp",
                                     "label": "Firewall Private IP Address",
                                     "type": "Microsoft.Common.TextBox",
@@ -571,9 +597,9 @@
                                 },
                                 {
                                     "name": "dnsServerAdresses",
-                                    "label": "DNS Server Addresses",
+                                    "label": "DNS Forwarder IP Addresses",
                                     "type": "Microsoft.Common.TextBox",
-                                    "visible": "[equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'custom')]",
+                                    "visible": "[equals(steps('connectivitySettings').firewallConfiguration.existingDnsForwarderType, 'custom')]",
                                     "defaultValue": "10.0.0.4",
                                     "toolTip": "Specify the private IP addresses of your DNS forwarders. You can specify more than one private IP address ('10.0.0.4,10.0.0.5').",
                                     "constraints": {
@@ -581,7 +607,7 @@
                                         "validations": [
                                             {
                                                 "regex": "^((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(,)?)*$",
-                                                "message": "Invalid IP addresses. Please specify one or more valid IP adresses (e.g. '10.0.0.4' or '10.0.0.4,10.0.0.5')."
+                                                "message": "Invalid IP addresses. Please specify one or more valid IP adresses (e.g. '10.0.0.4' or '10.0.0.4,10.0.0.5') and remove whitespaces in your input."
                                             }
                                         ]
                                     }
@@ -829,7 +855,7 @@
                 "servicesSubnetAddressPrefix": "[if(empty(steps('connectivitySettings').virtualNetworkConfiguration.servicesSubnetCidrRange), '', steps('connectivitySettings').virtualNetworkConfiguration.servicesSubnetCidrRange)]",
                 "enableDnsAndFirewallDeployment": "[if(equals(steps('connectivitySettings').firewallConfiguration.disableDnsAndFirewallDeployment, 'no'), true, false)]",
                 "firewallPrivateIp": "[if(equals(steps('connectivitySettings').firewallConfiguration.disableDnsAndFirewallDeployment, 'no'), '', if(equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'azureFirewall'), first(map(steps('connectivitySettings').firewallConfiguration.azureFirewallPrivateIpApi.properties.ipConfigurations, (item) => item.properties.privateIPAddress)), steps('connectivitySettings').firewallConfiguration.firewallPrivateIp))]",
-                "dnsServerAdresses": "[if(equals(steps('connectivitySettings').firewallConfiguration.disableDnsAndFirewallDeployment, 'no'), parse('[]'), if(equals(steps('connectivitySettings').firewallConfiguration.existingFirewallType, 'azureFirewall'), map(steps('connectivitySettings').firewallConfiguration.azureFirewallPrivateIpApi.properties.ipConfigurations, (item) => item.properties.privateIPAddress), split(steps('connectivitySettings').firewallConfiguration.dnsServerAdresses, ',')))]",
+                "dnsServerAdresses": "[if(equals(steps('connectivitySettings').firewallConfiguration.disableDnsAndFirewallDeployment, 'no'), parse('[]'), if(equals(steps('connectivitySettings').firewallConfiguration.existingDnsForwarderType, 'azureFirewall'), map(steps('connectivitySettings').firewallConfiguration.azureFirewallPrivateIpApi.properties.ipConfigurations, (item) => item.properties.privateIPAddress), split(replace(steps('connectivitySettings').firewallConfiguration.dnsServerAdresses, ' ', ''), ',')))]",
                 "firewallPolicyId": "[if(empty(steps('connectivitySettings').firewallConfiguration.firewallPolicyId), '', steps('connectivitySettings').firewallConfiguration.firewallPolicyId)]",
                 "privateDnsZoneIdBlob": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdBlob), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdBlob)]",
                 "privateDnsZoneIdKeyVault": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault)]",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "17267303737142956023"
+      "templateHash": "14645738413971440377"
     }
   },
   "parameters": {
@@ -261,7 +261,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "7515835829504360486"
+              "templateHash": "1364315738341672417"
             }
           },
           "parameters": {
@@ -536,7 +536,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "12646215261701148621"
+                      "templateHash": "722980097855631450"
                     }
                   },
                   "parameters": {
@@ -750,11 +750,14 @@
                                   "*"
                                 ],
                                 "sourceIpGroups": [],
-                                "destinationAddresses": [],
-                                "destinationIpGroups": [],
-                                "destinationFqdns": [
-                                  "kms.core.windows.net"
+                                "destinationAddresses": [
+                                  "23.102.135.246",
+                                  "51.4.143.248",
+                                  "23.97.0.13",
+                                  "42.159.7.249"
                                 ],
+                                "destinationIpGroups": [],
+                                "destinationFqdns": [],
                                 "destinationPorts": [
                                   "1688"
                                 ],
@@ -1126,7 +1129,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "12646215261701148621"
+                      "templateHash": "722980097855631450"
                     }
                   },
                   "parameters": {
@@ -1340,11 +1343,14 @@
                                   "*"
                                 ],
                                 "sourceIpGroups": [],
-                                "destinationAddresses": [],
-                                "destinationIpGroups": [],
-                                "destinationFqdns": [
-                                  "kms.core.windows.net"
+                                "destinationAddresses": [
+                                  "23.102.135.246",
+                                  "51.4.143.248",
+                                  "23.97.0.13",
+                                  "42.159.7.249"
                                 ],
+                                "destinationIpGroups": [],
+                                "destinationFqdns": [],
                                 "destinationPorts": [
                                   "1688"
                                 ],

--- a/infra/modules/services/firewallPolicyRules.bicep
+++ b/infra/modules/services/firewallPolicyRules.bicep
@@ -212,10 +212,18 @@ resource networkRules 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2
               '*'
             ]
             sourceIpGroups: []
-            destinationAddresses: []
+            destinationAddresses: [
+              '23.102.135.246'  // Required IPs for Windows Activation (https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/custom-routes-enable-kms-activation#solution).
+              '51.4.143.248'
+              '23.97.0.13'
+              '42.159.7.249'
+            ]
             destinationIpGroups: []
             destinationFqdns: [
-              'kms.core.windows.net'
+              // 'kms.core.windows.net'  // FQDNs instead of hardcoded IPs can only be used, if the firewall policy has the DNS forwrder setting turned on. For compatibility reasons we will rely on IPs.
+              // 'kms.core.cloudapi.de'
+              // 'kms.core.usgovcloudapi.net'
+              // 'kms.core.chinacloudapi.cn'
             ]
             destinationPorts: [
               '1688'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
* Improve Portal experience so that users can select custom DNS Forwarder even though they have selected Azure Firewall as their Firewall. Not all customers use the DNS forwarder feature of Azure Firewall, which is why we need this enhancement.
* Update of Firewall network rules and relying on IPs instead of FQDNs for compatibility reasons. I added comments to the code to make this clear for users.