### PR TITLE
Added Additional Purview Outputs

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -197,6 +197,8 @@ resource managementResourceGroup 'Microsoft.Resources/resourceGroups@2021-01-01'
 output vnetId string = networkServices.outputs.vnetId
 output firewallPrivateIp string = networkServices.outputs.firewallPrivateIp
 output purviewId string = governanceResources.outputs.purviewId
+output purviewManagedStorageId string = governanceResources.outputs.purviewManagedStorageId
+output purviewManagedEventHubId string = governanceResources.outputs.purviewManagedEventHubId
 output privateDnsZoneIdKeyVault string = enableDnsAndFirewallDeployment ? globalDnsZones.outputs.privateDnsZoneIdKeyVault : ''
 output privateDnsZoneIdDataFactory string = enableDnsAndFirewallDeployment ? globalDnsZones.outputs.privateDnsZoneIdDataFactory : ''
 output privateDnsZoneIdDataFactoryPortal string = enableDnsAndFirewallDeployment ? globalDnsZones.outputs.privateDnsZoneIdDataFactoryPortal : ''

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "9055763377870284445"
+      "templateHash": "4087825762436790606"
     }
   },
   "parameters": {
@@ -2055,7 +2055,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "7767679708356243486"
+              "templateHash": "4473469867800634757"
             }
           },
           "parameters": {
@@ -2147,7 +2147,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.613.9944",
-                      "templateHash": "9950942984261810285"
+                      "templateHash": "17646672709394268624"
                     }
                   },
                   "parameters": {
@@ -2463,6 +2463,14 @@
                     "purviewId": {
                       "type": "string",
                       "value": "[resourceId('Microsoft.Purview/accounts', parameters('purviewName'))]"
+                    },
+                    "purviewManagedStorageId": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Purview/accounts', parameters('purviewName'))).managedResources.storageAccount]"
+                    },
+                    "purviewManagedEventHubId": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Purview/accounts', parameters('purviewName'))).managedResources.eventHubNamespace]"
                     }
                   }
                 }
@@ -2680,6 +2688,14 @@
             "purviewId": {
               "type": "string",
               "value": "[reference(resourceId('Microsoft.Resources/deployments', 'purview001'), '2019-10-01').outputs.purviewId.value]"
+            },
+            "purviewManagedStorageId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'purview001'), '2019-10-01').outputs.purviewManagedStorageId.value]"
+            },
+            "purviewManagedEventHubId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'purview001'), '2019-10-01').outputs.purviewManagedEventHubId.value]"
             }
           }
         }
@@ -3130,6 +3146,14 @@
     "purviewId": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-governance', variables('name'))), 'Microsoft.Resources/deployments', 'governanceResources'), '2019-10-01').outputs.purviewId.value]"
+    },
+    "purviewManagedStorageId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-governance', variables('name'))), 'Microsoft.Resources/deployments', 'governanceResources'), '2019-10-01').outputs.purviewManagedStorageId.value]"
+    },
+    "purviewManagedEventHubId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-governance', variables('name'))), 'Microsoft.Resources/deployments', 'governanceResources'), '2019-10-01').outputs.purviewManagedEventHubId.value]"
     },
     "privateDnsZoneIdKeyVault": {
       "type": "string",

--- a/infra/modules/governance.bicep
+++ b/infra/modules/governance.bicep
@@ -61,3 +61,5 @@ module purviewKeyVaultRoleAssignment 'auxiliary/purviewRoleAssignment.bicep' = {
 
 // Outputs
 output purviewId string = purview001.outputs.purviewId
+output purviewManagedStorageId string = purview001.outputs.purviewManagedStorageId
+output purviewManagedEventHubId string = purview001.outputs.purviewManagedEventHubId

--- a/infra/modules/services/purview.bicep
+++ b/infra/modules/services/purview.bicep
@@ -254,3 +254,5 @@ resource purviewPrivateEndpointNamespaceARecord 'Microsoft.Network/privateEndpoi
 
 // Outputs
 output purviewId string = purview.id
+output purviewManagedStorageId string = purview.properties.managedResources.storageAccount
+output purviewManagedEventHubId string = purview.properties.managedResources.eventHubNamespace


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
This PR will add additional outputs for teh central Purview instance, including the resource ID of the managed storage account as well as the managed event hub. This will be required for further enhancements and integration of Purview into the Data Landing Zones as well as Data Products.
