### PR TITLE
Purview default deployment region update

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -29,6 +29,7 @@ MD026:
 MD029: false                  # Ordered list item prefix
 MD033: false                  # Allow inline HTML
 MD036: false                  # Emphasis used instead of a heading
+MD037: false
 MD041: false
 
 #################

--- a/docs/EnterpriseScaleAnalytics-Prerequisites.md
+++ b/docs/EnterpriseScaleAnalytics-Prerequisites.md
@@ -48,19 +48,21 @@ For now, we are recommending to select one of the regions mentioned below. The l
 - (Africa) South Africa North
 - (Asia Pacific) Southeast Asia
 - (Asia Pacific) Australia East
-- (Asia Pacific) Japan East
+- (Asia Pacific) Japan East (*)
 - (Canada) Canada Central
 - (Europe) North Europe
 - (Europe) West Europe
-- (Europe) France Central
-- (Europe) Germany West Central
+- (Europe) France Central (*)
+- (Europe) Germany West Central (*)
 - (Europe) UK South
 - (South America) Brazil South
-- (US) Central US
+- (US) Central US (*)
 - (US) East US
 - (US) East US 2
 - (US) South Central US
 - (US) West US 2
+
+(*) *When the regions currently not supporting Azure Purview gets selected, the Azure Purview deployment gets performed on the default region  (Europe) North Europe*.
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR is to address the problem raised at issue  #208 in data-landing-zones repo. Since the problem is about Purview deployment regions, we added the default region info to show how we cover for regions where purview is not supported.
