### PR TITLE
Added Option to Select VM Image

### DIFF
--- a/docs/reference/bastionhost/main.bicep
+++ b/docs/reference/bastionhost/main.bicep
@@ -35,6 +35,12 @@ param jumpboxSubnetAddressPrefix string = '10.1.11.0/24'
 // Virtual Machine parameters
 @description('Specifies the SKU of the virtual machine that gets created.')
 param virtualMachineSku string = 'Standard_DS2_v2'
+@allowed([
+  'Windows10'
+  'WindowsServer2022'
+])
+@description('Specifies the image of the virtual machine that gets created.')
+param virtualMachineImage string = 'Windows10'
 @description('Specifies the administrator username of the virtual machine.')
 param administratorUsername string = 'VmMainUser'
 @secure()
@@ -86,6 +92,7 @@ module bastionServices 'modules/bastion.bicep' = {
     prefix: name
     tags: tagsJoined
     virtualMachineSku: virtualMachineSku
+    virtualMachineImage: virtualMachineImage
     bastionSubnetId: networkServices.outputs.bastionSubnetId
     jumpboxSubnetId: networkServices.outputs.jumpboxSubnetId
     administratorUsername: administratorUsername

--- a/docs/reference/bastionhost/main.json
+++ b/docs/reference/bastionhost/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "6987624965477586384"
+      "templateHash": "9175258774835994841"
     }
   },
   "parameters": {
@@ -80,6 +80,17 @@
       "metadata": {
         "description": "Specifies the SKU of the virtual machine that gets created."
       }
+    },
+    "virtualMachineImage": {
+      "type": "string",
+      "defaultValue": "Windows10",
+      "metadata": {
+        "description": "Specifies the image of the virtual machine that gets created."
+      },
+      "allowedValues": [
+        "Windows10",
+        "WindowsServer2022"
+      ]
     },
     "administratorUsername": {
       "type": "string",
@@ -442,6 +453,9 @@
           "virtualMachineSku": {
             "value": "[parameters('virtualMachineSku')]"
           },
+          "virtualMachineImage": {
+            "value": "[parameters('virtualMachineImage')]"
+          },
           "bastionSubnetId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('vnetSubscriptionId'), variables('vnetResourceGroupName')), 'Microsoft.Resources/deployments', 'networkServices'), '2020-06-01').outputs.bastionSubnetId.value]"
           },
@@ -462,7 +476,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "4537990983907796400"
+              "templateHash": "11116377257653460648"
             }
           },
           "parameters": {
@@ -484,6 +498,14 @@
             "virtualMachineSku": {
               "type": "string",
               "defaultValue": "Standard_DS2_v2"
+            },
+            "virtualMachineImage": {
+              "type": "string",
+              "defaultValue": "Windows10",
+              "allowedValues": [
+                "Windows10",
+                "WindowsServer2022"
+              ]
             },
             "administratorUsername": {
               "type": "string",
@@ -625,6 +647,9 @@
                   "virtualMachineSku": {
                     "value": "[parameters('virtualMachineSku')]"
                   },
+                  "virtualMachineImage": {
+                    "value": "[parameters('virtualMachineImage')]"
+                  },
                   "administratorUsername": {
                     "value": "[parameters('administratorUsername')]"
                   },
@@ -639,7 +664,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.4.1008.15138",
-                      "templateHash": "14575974093809669092"
+                      "templateHash": "10043636214272501728"
                     }
                   },
                   "parameters": {
@@ -656,6 +681,14 @@
                       "type": "string",
                       "defaultValue": "Standard_DS2_v2"
                     },
+                    "virtualMachineImage": {
+                      "type": "string",
+                      "defaultValue": "Windows10",
+                      "allowedValues": [
+                        "Windows10",
+                        "WindowsServer2022"
+                      ]
+                    },
                     "administratorUsername": {
                       "type": "string",
                       "defaultValue": "VmMainUser"
@@ -670,7 +703,19 @@
                   "functions": [],
                   "variables": {
                     "nicName": "[format('{0}-nic', parameters('virtualmachineName'))]",
-                    "diskName": "[format('{0}-disk', parameters('virtualmachineName'))]"
+                    "diskName": "[format('{0}-disk', parameters('virtualmachineName'))]",
+                    "imageReferenceWindows10": {
+                      "publisher": "MicrosoftWindowsDesktop",
+                      "offer": "Windows-10",
+                      "sku": "20h2-pro",
+                      "version": "latest"
+                    },
+                    "imageReferenceWindowsServer2022": {
+                      "publisher": "MicrosoftWindowsServer",
+                      "offer": "WindowsServer",
+                      "sku": "2022-datacenter",
+                      "version": "latest"
+                    }
                   },
                   "resources": [
                     {
@@ -729,12 +774,7 @@
                         },
                         "priority": "Regular",
                         "storageProfile": {
-                          "imageReference": {
-                            "offer": "WindowsServer",
-                            "publisher": "MicrosoftWindowsServer",
-                            "sku": "2022-datacenter",
-                            "version": "latest"
-                          },
+                          "imageReference": "[if(equals(parameters('virtualMachineImage'), 'Windows10'), variables('imageReferenceWindows10'), variables('imageReferenceWindowsServer2022'))]",
                           "osDisk": {
                             "name": "[variables('diskName')]",
                             "caching": "ReadWrite",

--- a/docs/reference/bastionhost/modules/bastion.bicep
+++ b/docs/reference/bastionhost/modules/bastion.bicep
@@ -12,6 +12,11 @@ param tags object
 param bastionSubnetId string
 param jumpboxSubnetId string
 param virtualMachineSku string = 'Standard_DS2_v2'
+@allowed([
+  'Windows10'
+  'WindowsServer2022'
+])
+param virtualMachineImage string = 'Windows10'
 param administratorUsername string = 'VmMainUser'
 @secure()
 param administratorPassword string
@@ -41,6 +46,7 @@ module virtualMachine001 'services/virtualmachine.bicep' = {
     subnetId: jumpboxSubnetId
     virtualmachineName: virtualMachine001Name
     virtualMachineSku: virtualMachineSku
+    virtualMachineImage: virtualMachineImage
     administratorUsername: administratorUsername
     administratorPassword: administratorPassword
   }

--- a/docs/reference/bastionhost/modules/services/virtualmachine.bicep
+++ b/docs/reference/bastionhost/modules/services/virtualmachine.bicep
@@ -10,6 +10,11 @@ param location string
 param tags object
 param virtualmachineName string
 param virtualMachineSku string = 'Standard_DS2_v2'
+@allowed([
+  'Windows10'
+  'WindowsServer2022'
+])
+param virtualMachineImage string = 'Windows10'
 param administratorUsername string = 'VmMainUser'
 @secure()
 param administratorPassword string
@@ -18,6 +23,18 @@ param subnetId string
 // Variables
 var nicName = '${virtualmachineName}-nic'
 var diskName = '${virtualmachineName}-disk'
+var imageReferenceWindows10 = {
+  publisher: 'MicrosoftWindowsDesktop'
+  offer: 'Windows-10'
+  sku: '20h2-pro'
+  version: 'latest'
+}
+var imageReferenceWindowsServer2022 = {
+  publisher: 'MicrosoftWindowsServer'
+  offer: 'WindowsServer'
+  sku: '2022-datacenter'
+  version: 'latest'
+}
 
 // Resources
 resource nic 'Microsoft.Network/networkInterfaces@2021-02-01' = {
@@ -73,12 +90,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-04-01' = {
     }
     priority: 'Regular'
     storageProfile: {
-      imageReference: {
-        offer: 'WindowsServer'
-        publisher: 'MicrosoftWindowsServer'
-        sku: '2022-datacenter'
-        version: 'latest'
-      }
+      imageReference: virtualMachineImage == 'Windows10' ? imageReferenceWindows10 : imageReferenceWindowsServer2022
       osDisk: {
         name: diskName
         caching: 'ReadWrite'

--- a/docs/reference/bastionhost/portal.json
+++ b/docs/reference/bastionhost/portal.json
@@ -266,6 +266,34 @@
                                         ],
                                         "required": true
                                     }
+                                },
+                                {
+                                    "name": "virtualMachineImage",
+                                    "label": "VM Image",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": true,
+                                    "defaultValue": "Windows 10",
+                                    "toolTip": "Specify the SKU of the Virtual Machine.",
+                                    "multiselect": false,
+                                    "selectAll": false,
+                                    "filter": true,
+                                    "filterPlaceholder": "Filter items ...",
+                                    "multiLine": true,
+                                    "constraints": {
+                                        "allowedValues": [
+                                            {
+                                                "label": "Windows 10",
+                                                "description": "Windows 10 Pro 20H2",
+                                                "value": "Windows10"
+                                            },
+                                            {
+                                                "label": "Windows Server 2022",
+                                                "description": "Windows Server 2022 Datacenter",
+                                                "value": "WindowsServer2022"
+                                            }
+                                        ],
+                                        "required": true
+                                    }
                                 }
                             ]
                         }
@@ -487,6 +515,7 @@
                 "bastionSubnetAddressPrefix": "[if(empty(steps('connectivitySettings').subnetConfiguration.bastionSubnetCidrRange), '', steps('connectivitySettings').subnetConfiguration.bastionSubnetCidrRange)]",
                 "jumpboxSubnetAddressPrefix": "[if(empty(steps('connectivitySettings').subnetConfiguration.jumpboxSubnetAddressPrefix), '', steps('connectivitySettings').subnetConfiguration.jumpboxSubnetAddressPrefix)]",
                 "virtualMachineSku": "[if(empty(steps('generalSettings').virtualMachineSettings.virtualMachineSku), '', steps('generalSettings').virtualMachineSettings.virtualMachineSku)]",
+                "virtualMachineImage": "[if(empty(steps('generalSettings').virtualMachineSettings.virtualMachineImage), '', steps('generalSettings').virtualMachineSettings.virtualMachineImage)]",
                 "administratorUsername": "[if(empty(steps('generalSettings').virtualMachineSettings.administratorUsername), '', steps('generalSettings').virtualMachineSettings.administratorUsername)]",
                 "administratorPassword": "[if(empty(steps('generalSettings').virtualMachineSettings.administratorPassword.password), '', steps('generalSettings').virtualMachineSettings.administratorPassword.password)]"
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
This PR will add the option to select a VM Image. Users will be able to select between Windows Server 2022 Datacenter and Windows 10 Pro.